### PR TITLE
:sparkles: Feat : 예외 처리 handler 추가

### DIFF
--- a/src/main/java/com/doodling/aop/GlobalExceptionHandler.java
+++ b/src/main/java/com/doodling/aop/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.doodling.aop;
+
+import com.doodling.exception.CustomException;
+import com.doodling.exception.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+    log.error("CustomException occurred: {}", e.getErrorCode().getDetail());
+    return ErrorResponse.toResponseEntity(e.getErrorCode());
+  }
+}

--- a/src/main/java/com/doodling/exception/CustomException.java
+++ b/src/main/java/com/doodling/exception/CustomException.java
@@ -1,0 +1,11 @@
+package com.doodling.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+}

--- a/src/main/java/com/doodling/exception/ErrorCode.java
+++ b/src/main/java/com/doodling/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.doodling.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+  /* code: 400 */
+  INVALID_REFRESH_TOKEN(BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
+
+  /* code: 401 */
+  INVALID_AUTH_TOKEN(UNAUTHORIZED, "권한 정보가 없는 토큰입니다."),
+  INVALID_USERNAME(UNAUTHORIZED, "username이 올바르지 않습니다."),
+  INVALID_MEMBER_ID(UNAUTHORIZED, "member Id가 올바르지 않습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String detail;
+}

--- a/src/main/java/com/doodling/exception/ErrorResponse.java
+++ b/src/main/java/com/doodling/exception/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.doodling.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+  private final String error;
+  private final Integer status;
+  private final String msg;
+
+  public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode errorCode) {
+    return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ErrorResponse.builder()
+                    .status(errorCode.getHttpStatus().value())
+                    .error(errorCode.getHttpStatus().name())
+                    .msg(errorCode.getDetail())
+                    .build()
+            );
+  }
+}

--- a/src/main/java/com/doodling/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/doodling/member/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.doodling.member.service;
 
+import com.doodling.exception.CustomException;
 import com.doodling.member.domain.Member;
 import com.doodling.member.dto.MyInfoResponseDTO;
 
@@ -22,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.doodling.exception.ErrorCode.INVALID_MEMBER_ID;
 
 @RequiredArgsConstructor
 @Service
@@ -78,11 +81,7 @@ public class MemberServiceImpl implements MemberService {
   @Override
   public MyInfoResponseDTO getMyInfo(Integer memberId) {
     Optional<Member> optional_member = memberMapper.findByMemberId(memberId);
-    if (optional_member.isEmpty()) {
-      /* TODO: 에러 처리 필요 */
-      log.error("member 정보를 찾을 수 없습니다.");
-      return null;
-    }
+    optional_member.orElseThrow(() -> new CustomException(INVALID_MEMBER_ID));
 
     Member member = optional_member.get();
     return MyInfoResponseDTO.builder()


### PR DESCRIPTION
## 📌 작업
- 예외 처리를 하기 위한 클래스 생성
- 예외 처리 예제 추가
- 예외 처리 handler 구현 -> `GlobalExceptionHandler`

## 🔍 결과 및 이슈 공유
<img width="604" alt="image" src="https://github.com/moka-doodling/server/assets/38252649/2fe60068-fa9d-4c0e-a39c-af9c725d44c3">

close #8 
